### PR TITLE
Prior calculation performance for 1000+ mutations 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from bitnami/minideb
+from bitnami/minideb:buster
 RUN install_packages python-pip build-essential python-dev r-base r-base-dev git graphviz python-tk
 RUN pip install setuptools wheel
 RUN pip install numpy scipy matplotlib pandas


### PR DESCRIPTION
Had some issues with this for large samples, but since we first wrote the software there's been a new approximation for logstirling coefficients developed:

> Swaine L Chen, Nico M Temme, A Faster and More Accurate Algorithm for Calculating Population Genetics Statistics Requiring Sums of Stirling Numbers of the First Kind, G3 Genes|Genomes|Genetics, Volume 10, Issue 11, 1 November 2020, Pages 3959–3967, [https://doi.org/10.1534/g3.120.401575](https://doi.org/10.1534/g3.120.401575 )

I have adapted this to the prior calculation, and fixed the docker build file to test. 

For ~1000 mutations, takes the prior calculation from nearly a minute to almost instant, with minor error: 
```
Old: {'a': 1.2355127299648985, 'b': 3.285775232976865, 'KL_divergence': 1.0388836127098066e-05}
New: {'a': 1.2360983922422462, 'b': 3.2871978856161417, 'KL_divergence': 1.0392287138662582e-05}
```

For 10,000 mutations, the old calculation took 20 minutes, and now it takes seconds. 
```
Old: {'a': 1.2716390989170585,  'b': 4.230418159369041, 'KL_divergence': 1.3294329165569607e-05}
New: {'a': 1.2718892362810572, 'b': 4.230767762902994, 'KL_divergence': 1.329728110259154e-05}
```

There is no difference in clustering results between the versions. 

