### PR TITLE
Fix NDHistogram iteration bug in DpEngine (.items() → .iteritems() / _hist_array) and add Python 3 conda environment file

### DIFF
--- a/Cluster/DpEngine.py
+++ b/Cluster/DpEngine.py
@@ -81,8 +81,8 @@ class DpEngine:
             mut_iter = iter(data.items())
         elif hasattr(data, "iteritems"):
             mut_iter = data.iteritems()
-        elif hasattr(data, "_hist_array"):
-            mut_iter = ((i, v) for i, v in enumerate(data._hist_array))
+        # elif hasattr(data, "_hist_array"):
+        #     mut_iter = ((i, v) for i, v in enumerate(data._hist_array))
         else:
             raise TypeError("Unsupported data type for DpEngine: {}".format(type(data)))
         s_cluster = DP_cluster(self, DP_item(next(mut_iter)[0], self))
@@ -250,8 +250,13 @@ class DpEngine:
         # Flatten for TSNE and summary.
         log_data_flattened = []
 
-        for label, mutation in self.data.items():
-            log_data_flattened.append(mutation.flatten())
+        # NDHistogram has .iteritems(), not .items()
+        if hasattr(self.data, "items"):
+            for label, mutation in self.data.items():
+                log_data_flattened.append(mutation.flatten())
+        elif hasattr(self.data, "iteritems"):
+            for label, mutation in self.data.iteritems():
+                log_data_flattened.append(mutation.flatten())
 
         '''Normalize for TSNE'''
 

--- a/Cluster/DpEngine.py
+++ b/Cluster/DpEngine.py
@@ -76,7 +76,15 @@ class DpEngine:
         if N_iter == 0:
             return None
 
-        mut_iter = iter(data.items())
+        # NDHistogram has .iteritems(), not .items()
+        if hasattr(data, "items"):
+            mut_iter = iter(data.items())
+        elif hasattr(data, "iteritems"):
+            mut_iter = data.iteritems()
+        elif hasattr(data, "_hist_array"):
+            mut_iter = ((i, v) for i, v in enumerate(data._hist_array))
+        else:
+            raise TypeError("Unsupported data type for DpEngine: {}".format(type(data)))
         s_cluster = DP_cluster(self, DP_item(next(mut_iter)[0], self))
 
         for label, mut_hist in mut_iter:

--- a/envs/phylogicndt_py3.yml
+++ b/envs/phylogicndt_py3.yml
@@ -1,0 +1,24 @@
+name: phylogicndt_py3
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - pip
+  - setuptools
+  - wheel
+  # scientific stack from conda
+  - numpy=1.24.2
+  - scipy=1.10.1
+  - pandas=1.5.3
+  - matplotlib=3.6.3
+  - seaborn=0.12.2
+  - scikit-learn=1.3.0
+  - networkx=2.8.8
+  - intervaltree=2.1.0
+  - graphviz
+  - python-graphviz
+  # optional R support
+  - r-base=4.3
+  - pip:
+      - sselogsumexp @ git+https://github.com/rmcgibbo/logsumexp.git

--- a/output/PhylogicOutput.py
+++ b/output/PhylogicOutput.py
@@ -1041,7 +1041,13 @@ class PhylogicOutput(object):
         """
         import pandas as pd
         df = pd.DataFrame(trees_mcmc_trace)
-        df = df.sort_values(by='n_iter', ascending=False)
+        # Stable sort: among trees tied on n_iter, preserve insertion order so that
+        # row 0 of the posteriors file is the SAME tree BuildTreeEngine._most_common_tree()
+        # selects as top_tree (it breaks ties by first-inserted). This keeps the pie plot
+        # / tree diagram (which use edges_list[0]) consistent with the constrained CCFs
+        # (computed against top_tree). A non-stable sort can pick a different tied tree,
+        # producing negative pie wedges -> "Wedge sizes 'x' must be non negative values".
+        df = df.sort_values(by='n_iter', ascending=False, kind='mergesort')
         df['edges'] = df['edges'].apply(self.reformat_edges_for_output)
         df = df[['n_iter', 'likelihood', 'edges']]
         output_file = indiv_id + '_build_tree_posteriors.tsv'


### PR DESCRIPTION
**Description**

When running the Cluster module on the python3 branch, the following error occurs:

AttributeError: 'NDHistogram' object has no attribute 'items'


This happens because the code in Cluster/DpEngine.py assumed the input histogram was a Python dict and called .items(). In reality, on the Python 3 branch, the object is a data.Patient.NDHistogram, which exposes .iteritems() (a custom method retained from Python 2 style) and _hist_array.

**Fix**

Updated DpEngine.__init__ to handle both dict-like inputs and NDHistogram objects.

Added a fallback using .iteritems()  to maintain compatibility.

This ensures clustering runs correctly on the Python 3 branch.

**Environment**

To simplify setup for Python 3 users, I’ve added a conda environment file (phylogicndt_py3.yml) with tested dependencies. This avoids ABI conflicts by using conda for the scientific stack and pip only where required.
